### PR TITLE
issue with DIVS instruction

### DIFF
--- a/sae/cpu.js
+++ b/sae/cpu.js
@@ -1063,7 +1063,7 @@ function CPU() {
 			regs.pc = fault.pc;
 			return exception(5);
 		} else {
-			var quo = Math.floor(d / s);
+			var quo = ~~(d / s);
 
 			if (quo < 0) quo += 0x10000;
 


### PR DESCRIPTION
math.floor in divs rounds down away from 0 with negative numbers. Replaced with double binary not so that it always truncates regardless of whether +ve or -ve
