### PR TITLE
HTML5 Gamepad API

### DIFF
--- a/index.css
+++ b/index.css
@@ -63,6 +63,8 @@ input[type=text] {
 
 /*---------------------------------*/
 
+.hidden { display: none; }
+
 .gray { color:gray; }
 .green { color:green; }
 .orange { color:orange; }

--- a/index.htm
+++ b/index.htm
@@ -1487,16 +1487,17 @@
 								<div class="page" id="cfg_page_ports">
 									<table>
 										<tr>
-											<td class="arm">Mouse</td>
+											<td class="arm">Port 1</td>
 											<td>
 												<select id="cfg_ports_0" size="1" onchange="portUpdate(0)">
 													<option value="0">Disabled</option>
 													<option value="1">Mouse</option>
 													<option value="2">Joystick</option>
+													<option value="3">Emulated</option>
 												</select>
 											</td>
 											<td>
-												<div id="cfg_ports_0_grp">
+												<div id="cfg_ports_0_joyemu_grp">
 													Move
 													<select id="cfg_ports_0_move" size="1">
 														<option value="1">Arrows</option>
@@ -1556,19 +1557,27 @@
 														<option value="50">2</option>
 													</select>
 												</div>
+												<div id="cfg_ports_0_joy_grp" class="hidden">
+													Device
+													<select id="cfg_ports_0_joy_device" size="1">
+														<option value="0" disabled>No controllers detected</option>
+														<!-- Populated with connected gamepads via HTML5 Gamepad API -->
+													</select>											
+												</div>
 											</td>
 											<td style="width:100%"></td>
 										</tr>
 										<tr>
-											<td class="arm">Game</td>
+											<td class="arm">Port 2</td>
 											<td>
 												<select id="cfg_ports_1" size="1" onchange="portUpdate(1)">
 													<option value="0">Disabled</option>
-													<option value="3">Joystick</option>
+													<option value="2">Joystick</option>
+													<option value="3">Emulated</option>
 												</select>
 											</td>
 											<td>
-												<div id="cfg_ports_1_grp">
+												<div id="cfg_ports_1_joyemu_grp">
 													Move
 													<select id="cfg_ports_1_move" size="1">
 														<option value="1">Arrows</option>
@@ -1628,6 +1637,13 @@
 														<option value="50">2</option>
 													</select>
 												</div>
+												<div id="cfg_ports_1_joy_grp" class="hidden">
+													Device
+													<select id="cfg_ports_1_joy_device" size="1">
+														<option value="" disabled>No controllers detected</option>
+														<!-- Populated with connected gamepads via HTML5 Gamepad API -->
+													</select>
+												</div>                 
 											</td>
 											<td style="width:100%"></td>
 										</tr>
@@ -1638,7 +1654,7 @@
 										</tr>
 										<tr>
 											<td class="arm"><input id="cfg_keyborad_enabled" type="checkbox" /></td>
-											<td class="alm" colspan="3">Enabled <span class="info">(joystick-emulation does always work)</span></td>
+											<td class="alm" colspan="3">Enabled <span class="info">(joystick-emulation doesn't always work)</span></td>
 										</tr>
 										<tr><td colspan="4"><div style="height:10px"></div></td></tr>
 										<tr>

--- a/index.js
+++ b/index.js
@@ -1158,19 +1158,52 @@ function setAdvandedConfig() {
 	setSelect("cfg_ports_0_move", cfg.ports[0].move);
 	setSelect("cfg_ports_0_fire_1", cfg.ports[0].fire[0]);
 	setSelect("cfg_ports_0_fire_2", cfg.ports[0].fire[1]);
-	styleDisplayInline("cfg_ports_0_grp", cfg.ports[0].type == SAEC_Config_Ports_Type_Joy0);
-
+	styleDisplayInline("cfg_ports_0_joyemu_grp", cfg.ports[0].type == SAEC_Config_Ports_Type_JoyEmu);
+	styleDisplayInline("cfg_ports_0_joy_grp", cfg.ports[0].type == SAEC_Config_Ports_Type_Joy);
+	setAvailableGamepads('cfg_ports_0_joy_device');
+	
 	setSelect("cfg_ports_1", cfg.ports[1].type);
 	setSelect("cfg_ports_1_move", cfg.ports[1].move);
 	setSelect("cfg_ports_1_fire_1", cfg.ports[1].fire[0]);
 	setSelect("cfg_ports_1_fire_2", cfg.ports[1].fire[1]);
-	styleDisplayInline("cfg_ports_1_grp", cfg.ports[1].type == SAEC_Config_Ports_Type_Joy1);
-
+	styleDisplayInline("cfg_ports_1_joyemu_grp", cfg.ports[1].type == SAEC_Config_Ports_Type_JoyEmu);
+	styleDisplayInline("cfg_ports_1_joy_grp", cfg.ports[1].type == SAEC_Config_Ports_Type_Joy);
+	setAvailableGamepads('cfg_ports_1_joy_device');
+	
 	setCheckbox("cfg_keyborad_enabled", cfg.keyboard.enabled);
 
 	setCheckbox("cfg_serial_enabled", cfg.serial.enabled);
 
 	styleDisplayTableCell("controls_disk", 1);
+}
+
+function setAvailableGamepads( select_id ) {
+
+	var sel = document.getElementById(select_id);
+	var gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+
+	/* Clear list */
+	for(var i = sel.options.length - 1 ; i >= 0 ; i--) {sel.remove(i);};
+
+	/* Add gamepads */
+	for (i = 0; i < gamepads.length; i++) {
+		if (gamepads[i]) {
+			var opt = document.createElement('option');
+			opt.value = gamepads[i].index;
+			opt.innerHTML = gamepads[i].id + ' #' + i;
+			sel.appendChild(opt);
+		}
+	}
+
+
+	/* Add placeholder if no devices found */
+	if (sel.options.length == 0) {
+		var opt = document.createElement('option');
+		opt.value = '';
+		opt.innerHTML = 'No controllers detected';
+		opt.disabled = true;
+		sel.appendChild(opt);
+	}
 }
 
 function getAdvandedFloppy() {
@@ -1360,7 +1393,7 @@ function getAdvandedConfig() {
 
 	/* ports */
 	cfg.ports[0].type = getSelect("cfg_ports_0");
-	if (cfg.ports[0].type == SAEC_Config_Ports_Type_Joy0) {
+	if (cfg.ports[0].type == SAEC_Config_Ports_Type_JoyEmu) {
 		cfg.ports[0].move = getSelect("cfg_ports_0_move");
 		cfg.ports[0].fire[0] = getSelect("cfg_ports_0_fire_1");
 		cfg.ports[0].fire[1] = getSelect("cfg_ports_0_fire_2");
@@ -1369,8 +1402,12 @@ function getAdvandedConfig() {
 			return false;
 		}
 	}
+	if (cfg.ports[0].type == SAEC_Config_Ports_Type_Joy) {
+		cfg.ports[0].device = getSelect("cfg_ports_0_joy_device");
+	}
+  
 	cfg.ports[1].type = getSelect("cfg_ports_1");
-	if (cfg.ports[1].type == SAEC_Config_Ports_Type_Joy1) {
+	if (cfg.ports[1].type == SAEC_Config_Ports_Type_JoyEmu) {
 		cfg.ports[1].move = getSelect("cfg_ports_1_move");
 		cfg.ports[1].fire[0] = getSelect("cfg_ports_1_fire_1");
 		cfg.ports[1].fire[1] = getSelect("cfg_ports_1_fire_2");
@@ -1379,7 +1416,13 @@ function getAdvandedConfig() {
 			return false;
 		}
 	}
-
+	if (cfg.ports[1].type == SAEC_Config_Ports_Type_Joy) {
+		cfg.ports[1].device = getSelect("cfg_ports_1_joy_device");
+		if (cfg.ports[0].type == SAEC_Config_Ports_Type_Joy && cfg.ports[1].device == cfg.ports[0].device) {
+			alert("Joystick device on port 2 can't be the same device used on port 1.");
+			return false;
+		}
+	}
 	cfg.keyboard.enabled = getCheckbox("cfg_keyborad_enabled");
 
 	cfg.serial.enabled = getCheckbox("cfg_serial_enabled");
@@ -2460,11 +2503,20 @@ function channelsUpdate() {
 /*---------------------------------*/
 
 function portUpdate(n) {
-	var v = getSelect("cfg_ports_"+n);
-	if (n == 0)
-		styleDisplayInline("cfg_ports_0_grp", v == SAEC_Config_Ports_Type_Joy0);
-	else
-		styleDisplayInline("cfg_ports_1_grp", v == SAEC_Config_Ports_Type_Joy1);
+	var v = getSelect("cfg_ports_" + n);
+	if (n == 0) {
+		styleDisplayInline("cfg_ports_0_joyemu_grp", v == SAEC_Config_Ports_Type_JoyEmu);
+		styleDisplayInline("cfg_ports_0_joy_grp", v == SAEC_Config_Ports_Type_Joy);
+		if (v == SAEC_Config_Ports_Type_Joy) {
+			setAvailableGamepads("cfg_ports_0_joy_device");
+		}
+	} else {
+		styleDisplayInline("cfg_ports_1_joyemu_grp", v == SAEC_Config_Ports_Type_JoyEmu);
+		styleDisplayInline("cfg_ports_1_joy_grp", v == SAEC_Config_Ports_Type_Joy);
+		if (v == SAEC_Config_Ports_Type_Joy) {
+			setAvailableGamepads("cfg_ports_1_joy_device");
+		}
+	}
 }
 
 /*-----------------------------------------------------------------------*/

--- a/index.js
+++ b/index.js
@@ -1180,29 +1180,30 @@ function setAdvandedConfig() {
 function setAvailableGamepads( select_id ) {
 
 	var sel = document.getElementById(select_id);
-	var gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
-
-	/* Clear list */
-	for(var i = sel.options.length - 1 ; i >= 0 ; i--) {sel.remove(i);};
-
-	/* Add gamepads */
-	for (i = 0; i < gamepads.length; i++) {
-		if (gamepads[i]) {
+	if (sel) {
+		var gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+	
+		/* Clear list */
+		for(var i = sel.options.length - 1 ; i >= 0 ; i--) {sel.remove(i);};
+	
+		/* Add gamepads */
+		for (i = 0; i < gamepads.length; i++) {
+			if (gamepads[i]) {
+				var opt = document.createElement('option');
+				opt.value = gamepads[i].index;
+				opt.innerHTML = gamepads[i].id + ' #' + i;
+				sel.appendChild(opt);
+			}
+		}
+	
+	
+		/* Add placeholder if no devices found */
+		if (sel.options.length == 0) {
 			var opt = document.createElement('option');
-			opt.value = gamepads[i].index;
-			opt.innerHTML = gamepads[i].id + ' #' + i;
+			opt.value = '';
+			opt.innerHTML = 'Not Detected. Press a button on controller';
 			sel.appendChild(opt);
 		}
-	}
-
-
-	/* Add placeholder if no devices found */
-	if (sel.options.length == 0) {
-		var opt = document.createElement('option');
-		opt.value = '';
-		opt.innerHTML = 'No controllers detected';
-		opt.disabled = true;
-		sel.appendChild(opt);
 	}
 }
 
@@ -2731,3 +2732,17 @@ function dskchgSelect() {
 			sae.insert(n);
 	}
 }
+
+/* Detect changes in connected gamepads/joysticks */
+window.addEventListener("gamepadconnected", function(e) {
+	SAEF_log("New gamepad " + e.gamepad.id + " connected");
+	setAvailableGamepads('cfg_ports_0_joy_device'); 
+	setAvailableGamepads('cfg_ports_1_joy_device');
+});
+window.addEventListener("gamepaddisconnected", function(e) {
+	window.setTimeout(function(){
+		SAEF_log("Gamepad " + e.gamepad.id + " disconnected");
+		setAvailableGamepads('cfg_ports_0_joy_device');
+		setAvailableGamepads('cfg_ports_1_joy_device');
+	}, 100);
+});

--- a/sae/cia.js
+++ b/sae/cia.js
@@ -824,12 +824,18 @@ function SAEO_CIA() {
 		if (SAEV_config.ports[0].type == SAEC_Config_Ports_Type_Mouse) {
 			if (!SAER.input.mouse.button[0]) tmp |= 0x40;
 			if (dra & 0x40) tmp = (tmp & ~0x40) | (pra & 0x40);
-		} else if (SAEV_config.ports[0].type == SAEC_Config_Ports_Type_Joy0) {
+		} else if (
+			(SAEV_config.ports[0].type == SAEC_Config_Ports_Type_Joy) ||
+			(SAEV_config.ports[0].type == SAEC_Config_Ports_Type_JoyEmu)
+		) {
 			if (!SAER.input.joystick[0].button[0]) tmp |= 0x40;
 			if (dra & 0x40) tmp = (tmp & ~0x40) | (pra & 0x40);
 		} else tmp |= 0x40;
 
-		if (SAEV_config.ports[1].type == SAEC_Config_Ports_Type_Joy1) {
+		if (
+			(SAEV_config.ports[1].type == SAEC_Config_Ports_Type_Joy) ||
+			(SAEV_config.ports[1].type == SAEC_Config_Ports_Type_JoyEmu)
+		) {
 			if (!SAER.input.joystick[1].button[0]) tmp |= 0x80;
 			if (dra & 0x80) tmp = (tmp & ~0x80) | (pra & 0x80);
 		} else tmp |= 0x80;

--- a/sae/config.js
+++ b/sae/config.js
@@ -1161,7 +1161,7 @@ function SAEO_Configuration() {
 		p.ports[0].type = SAEC_Config_Ports_Type_Mouse;
 		p.ports[0].move = SAEC_Config_Ports_Move_WASD;
 		p.ports[0].fire = [49,50];
-		p.ports[1].type = SAEC_Config_Ports_Type_Joy;
+		p.ports[1].type = SAEC_Config_Ports_Type_JoyEmu;
 		p.ports[1].device = 0;
 		p.ports[1].move = SAEC_Config_Ports_Move_Arrows;
 		p.ports[1].fire = [16,17];

--- a/sae/config.js
+++ b/sae/config.js
@@ -372,8 +372,8 @@ const SAEC_Config_Audio_Interpol_Crux = 3;
 
 const SAEC_Config_Ports_Type_None = 0;
 const SAEC_Config_Ports_Type_Mouse = 1;
-const SAEC_Config_Ports_Type_Joy0 = 2;
-const SAEC_Config_Ports_Type_Joy1 = 3;
+const SAEC_Config_Ports_Type_Joy = 2;
+const SAEC_Config_Ports_Type_JoyEmu = 3;
 
 const SAEC_Config_Ports_Move_None = 0;
 const SAEC_Config_Ports_Move_Arrows = 1;
@@ -675,7 +675,7 @@ function SAEO_Config() {
 		move: SAEC_Config_Ports_Move_WASD,
 		fire: [49,50]
 	}, {
-		type: SAEC_Config_Ports_Type_Joy1,
+		type: SAEC_Config_Ports_Type_JoyEmu,
 		move: SAEC_Config_Ports_Move_Arrows,
 		fire: [16,17]
 	}];
@@ -1161,7 +1161,8 @@ function SAEO_Configuration() {
 		p.ports[0].type = SAEC_Config_Ports_Type_Mouse;
 		p.ports[0].move = SAEC_Config_Ports_Move_WASD;
 		p.ports[0].fire = [49,50];
-		p.ports[1].type = SAEC_Config_Ports_Type_Joy1;
+		p.ports[1].type = SAEC_Config_Ports_Type_Joy;
+		p.ports[1].device = 0;
 		p.ports[1].move = SAEC_Config_Ports_Move_Arrows;
 		p.ports[1].fire = [16,17];
 		/*memset (&p.jports[0], 0, sizeof (struct jport));


### PR DESCRIPTION
Changes to allow the use of physical game devices such as gamepads and joysticks on browsers that support the HTML5 Gamepad API.

To use a physical gamepad select "Joystick" for either port in Config->Ports. The existing emulated joystick can be selected by choosing "Emulated" from the same dropdown.

Tested on: 
* Firefox 54 and Chrome 59 on Windows 7
* Microsoft Edge 25 on Windows 10
* Firefox 54 on Linux Mint 15

Known Issues:
* Firefox requires a button on the controller to be pressed before controllers are detected
* Chrome only detects connection events when you switch to another tab and return (seriously??)
* Firefox calls devices "xinput" rather than finding the controller proper model name

These are all browser bugs so not much can be done about them.