### PR TITLE
Bugfix in DMS decompression with DEEP Compression

### DIFF
--- a/sae/dms.js
+++ b/sae/dms.js
@@ -325,10 +325,10 @@ function SAEO_DMS() {
 			//l = (j - k) << 1;
 			l = j - k;
 			//memmove(&freq[k + 1], &freq[k], (size_t)l);
-			for (m = l; m >= 0; m--) freq[k + m + 1] = freq[k + m];
+			for (m = l-1; m >= 0; m--) freq[k + m + 1] = freq[k + m];
 			freq[k] = f;
 			//memmove(&son[k + 1], &son[k], (size_t)l);
-			for (m = l; m >= 0; m--) son[k + m + 1] = son[k + m];
+			for (m = l-1; m >= 0; m--) son[k + m + 1] = son[k + m];
 			son[k] = i;
 		}
 		/* connect prnt */


### PR DESCRIPTION
Memmove in c moves exactly n bytes so the javascript loop moved 1 byte too much.
This resulted in a inconsistent freq table, resulting in endless loops in the "update" function when decompressing a track with DEEP compression.
If you need a reference file, you can find an example DMS at http://www.stef.be/adfviewer/disks/COOPAIM1.DMS